### PR TITLE
skip calling `Driver.parse_message/2` when not connected to socket

### DIFF
--- a/lib/graphql_ws_client.ex
+++ b/lib/graphql_ws_client.ex
@@ -505,14 +505,16 @@ defmodule GraphQLWSClient do
     {:noreply, State.remove_listener_by_pid(state, pid)}
   end
 
-  def handle_info(msg, %State{} = state) do
-    case Driver.parse_message(state.conn, msg) do
+  def handle_info(msg, %State{connected?: true, conn: conn} = state) do
+    case Driver.parse_message(conn, msg) do
       {:ok, msg} -> handle_message(msg, state)
       {:error, error} -> handle_error(error, state)
       :ignore -> {:noreply, state}
       :disconnect -> handle_socket_down(state)
     end
   end
+
+  def handle_info(_msg, state), do: {:noreply, state}
 
   defp handle_socket_down(%State{} = state) do
     Logger.warn("Websocket process went down: #{inspect(state.conn.pid)}")

--- a/test/graphql_ws_client_test.exs
+++ b/test/graphql_ws_client_test.exs
@@ -548,10 +548,21 @@ defmodule GraphQLWSClientTest do
       }
     end
 
-    test "ignored message", %{client: client} do
+    test "ignore message with unexpected format", %{client: client} do
       expect(MockDriver, :parse_message, fn @conn, :test_message ->
         :ignore
       end)
+
+      send(client, :test_message)
+
+      refute_receive %Event{}
+    end
+
+    test "ignore message when not connected", %{client: client} do
+      stub(MockDriver, :disconnect, fn @conn -> :ok end)
+
+      :ok = GraphQLWSClient.close(client)
+      refute GraphQLWSClient.connected?(client)
 
       send(client, :test_message)
 


### PR DESCRIPTION
close #3 